### PR TITLE
initial draft of CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## <a id="openParticipation">Public Participation Invited</a>
+
+PACE is a sub-project of the [Open Cybersecurity Alliance (OCA)](https://opencybersecurityalliance.org/), an [OASIS Open Project](https://oasis-open-projects.org/), and welcomes participation by anyone, whether affiliated with OASIS or not.  Substantive contributions and feedback are invited from all parties, following the common conventions for participation in GitHub public repository projects.  
+
+Participation is expected to be consistent with the [Code of Conduct](https://github.com/opencybersecurityalliance/oca-admin/blob/master/CODE_OF_CONDUCT.md), the [licenses](https://github.com/opencybersecurityalliance/oca-admin/blob/master/LICENSE.md), and the acceptance of our Contributor License Agreement, generally at the time of first contribution. Please see the repository [README](https://github.com/opencybersecurityalliance/oca-admin/blob/master/README.md) for more details.</p>
+
+## <a id="DevModel">Development Model</a>
+
+The PACE project operates using the GitHub ["Fork and Pull"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models#fork-and-pull-model) collaborative development model. Interested contributors are encourages to fork the PACE repository and provide contributions as pull requests. Pull request will be reviewed by maintainers and discussed in PACE working meetings, and merged if approved.
+
+PACE maintainers are selected by acclamation by the PACE working group, and are the only participants with the privileges to merge pull requests. The current maintainers are:
+
+ * Adam Montville, CIS, @adammontville
+ * Sara Archacki, CIS, 
+ * David Lemire, Huntington-Ingalls Industries, @dlemire60
+
+> Maintainers list updated 11 January 2022
+
+## <a id="feedback">Feedback</a>
+
+Questions or comments about the OCA's activities may be composed as GitHub issues or comments or may be directed to the project's general email list at oca@lists.oasis-open-projects.org. General questions about OASIS Open Projects may be directed to OASIS staff at op-admin@lists.oasis-open-projects.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 PACE is a sub-project of the [Open Cybersecurity Alliance (OCA)](https://opencybersecurityalliance.org/), an [OASIS Open Project](https://oasis-open-projects.org/), and welcomes participation by anyone, whether affiliated with OASIS or not.  Substantive contributions and feedback are invited from all parties, following the common conventions for participation in GitHub public repository projects.  
 
-Participation is expected to be consistent with the [Code of Conduct](https://github.com/opencybersecurityalliance/oca-admin/blob/master/CODE_OF_CONDUCT.md), the [licenses](https://github.com/opencybersecurityalliance/oca-admin/blob/master/LICENSE.md), and the acceptance of our Contributor License Agreement, generally at the time of first contribution. Please see the repository [README](https://github.com/opencybersecurityalliance/oca-admin/blob/master/README.md) for more details.</p>
+Participation is expected to be consistent with the [Code of Conduct](https://github.com/opencybersecurityalliance/oasis-open-project/blob/master/CODE_OF_CONDUCT.md), the [licenses](https://github.com/opencybersecurityalliance/oasis-open-project/blob/master/LICENSE.md), and the acceptance of our Contributor License Agreement, generally at the time of first contribution. Please see the repository [README](https://github.com/opencybersecurityalliance/oasis-open-project/blob/master/README.md) for more details.</p>
 
 ## <a id="DevModel">Development Model</a>
 
@@ -13,7 +13,7 @@ The PACE project operates using the GitHub ["Fork and Pull"](https://docs.github
 PACE maintainers are selected by acclamation by the PACE working group, and are the only participants with the privileges to merge pull requests. The current maintainers are:
 
  * Adam Montville, CIS, @adammontville
- * Sara Archacki, CIS, 
+ * Sara Archacki, CIS, @slarchacki22
  * David Lemire, Huntington-Ingalls Industries, @dlemire60
 
 > Maintainers list updated 11 January 2022


### PR DESCRIPTION
Initial draft of CONTRIBUTING file. Based on the the CONTRIBUTUING.md file in the OCA [oasis-open-project repo](https://github.com/opencybersecurityalliance/oasis-open-project), edited to incorporate decisions made at the 10 January 2022 PACE WG meeting (see [Adam Montville's notes](https://github.com/opencybersecurityalliance/PACE/issues/12#issuecomment-1009210386) on issue #12) 

Need a GitHub identifier for Sara A. to add to the maintainers list